### PR TITLE
Improved prompt to reply in the same language

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -8,7 +8,7 @@
     "description": "No API Key button content"
   },
   "instructions": {
-    "message": "Write a reply to this email. Answer to it step by step .\nEmail: \"\"\"",
+    "message": "Write a reply to this email in the same language as the email. Respond to each point in the email step by step.\nEmail: \"\"\"",
     "description": "Instructions for GPT. Using the same language helps the model to not be confuse in which language it should answer"
   },
   "popupFindIt": {


### PR DESCRIPTION
I modified the prompt (English only for now) so that it generates the reply in the same language as the original email. Previously, the answers were always generated in English even though I receive emails in multiple languages.

(Good job for this extension by the way and thank you for open sourcing it.)