### PR TITLE
Ask the user to provide a summary for the reply

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -8,8 +8,28 @@
     "description": "No API Key button content"
   },
   "instructions": {
-    "message": "Write a reply to this email in the same language as the email. Respond to each point in the email step by step.\nEmail: \"\"\"",
-    "description": "Instructions for GPT. Using the same language helps the model to not be confuse in which language it should answer"
+    "message": "Write a reply to this email in the same language as the email. Respond to each point in the email step by step.\nEmail: \"\"\"$email$\"\"\"",
+    "description": "Instructions for GPT. Using the same language helps the model to not be confuse in which language it should answer",
+    "placeholders": {
+      "email": {
+        "content": "$1",
+        "example": "Hi, how are you?"
+      }
+    }
+  },
+  "instructionsWithSummary": {
+    "message": "Write a reply to the following email in the same language as the email.\nThe reply should contain the following information: $summary$\nEmail: \"\"\"$email$\"\"\"",
+    "description": "Instructions for GPT. Using the same language helps the model to not be confuse in which language it should answer",
+    "placeholders": {
+      "email": {
+        "content": "$1",
+        "example": "Hi, how are you?"
+      },
+      "summary": {
+        "content": "$2",
+        "example": "I agree"
+      }
+    }
   },
   "popupFindIt": {
     "message": "Find it on",
@@ -38,5 +58,9 @@
   "popupChooseModel": {
       "message": "DaVinci > Curie > Babbage for capabilities, but Babbage > Curie > DaVinci for price and speed. Try them.",
       "description": "Label for GPT model selector"
+  },
+  "replySummaryPrompt": {
+    "message": "Summary of the reply:",
+    "description": "Prompt for the summary of the reply"
   }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1,42 +1,66 @@
 {
-    "answerWithGPT": {
-        "message": "Répondre avec GPT",
-        "description": "Normal button content"
-    },
-    "notConfigured": {
-        "message": "Configurez GPT",
-        "description": "No API Key button content"
-    },
-    "instructions": {
-        "message": "Ecrit une réponse à cet email, en reprenant point par point les attentes de l'interlocuteur.\nEmail: \"\"\"",
-        "description": "Instructions for GPT. Using the same language helps the model to not be confuse in which language it should answer"
-    },
-    "popupFindIt": {
-        "message": "Trouvez-la sur",
-        "description": "Beginning of sentence about where to find API Key"
-    },
-    "popupFindItLink": {
-        "message": "votre espace OpenAI",
-        "description": "End of the sentence about where to find API Key"
-    },
-    "popupUpdate": {
-        "message": "Mettre à jour",
-        "description": "Normal update button content"
-    },
-    "popupUpdateSuccess": {
-        "message": "Mis à jour !",
-        "description": "Success update button content"
-    },
-    "popupUpdateFail": {
-        "message": "Clé invalide !",
-        "description": "Fail update button content"
-    },
-    "popupModelLabel": {
-        "message": "Modèle d'IA",
-        "description": "Label for GPT model selector"
-    },
-    "popupChooseModel": {
-        "message": "DaVinci > Curie > Babbage pour leurs capacités, mais Babbage > Curie > DaVinci pour le prix et la vitesse. Essayez-les.",
-        "description": "Label for GPT model selector"
+  "answerWithGPT": {
+    "message": "Répondre avec GPT",
+    "description": "Normal button content"
+  },
+  "notConfigured": {
+    "message": "Configurez GPT",
+    "description": "No API Key button content"
+  },
+  "instructions": {
+    "message": "Ecrit une réponse à cet email, en reprenant point par point les attentes de l'interlocuteur.\nEmail: \"\"\"$email$\"\"\"",
+    "description": "Instructions for GPT. Using the same language helps the model to not be confuse in which language it should answer",
+    "placeholders": {
+      "email": {
+        "content": "$1",
+        "example": "Salut, comment vas-tu ?"
+      }
     }
+  },
+  "instructionsWithSummary": {
+    "message": "Ecrit une réponse à cet email, en reprenant point par point les attentes de l'interlocuteur.\nLa réponse doit contenir les informations suivantes: $summary$\nEmail: \"\"\"$email$\"\"\"",
+    "description": "Instructions for GPT. Using the same language helps the model to not be confuse in which language it should answer",
+    "placeholders": {
+      "email": {
+        "content": "$1",
+        "example": "Salut, comment vas-tu ?"
+      },
+      "summary": {
+        "content": "$2",
+        "example": "je suis d'accord"
+      }
+    }
+  },
+  "popupFindIt": {
+    "message": "Trouvez-la sur",
+    "description": "Beginning of sentence about where to find API Key"
+  },
+  "popupFindItLink": {
+    "message": "votre espace OpenAI",
+    "description": "End of the sentence about where to find API Key"
+  },
+  "popupUpdate": {
+    "message": "Mettre à jour",
+    "description": "Normal update button content"
+  },
+  "popupUpdateSuccess": {
+    "message": "Mis à jour !",
+    "description": "Success update button content"
+  },
+  "popupUpdateFail": {
+    "message": "Clé invalide !",
+    "description": "Fail update button content"
+  },
+  "popupModelLabel": {
+    "message": "Modèle d'IA",
+    "description": "Label for GPT model selector"
+  },
+  "popupChooseModel": {
+    "message": "DaVinci > Curie > Babbage pour leurs capacités, mais Babbage > Curie > DaVinci pour le prix et la vitesse. Essayez-les.",
+    "description": "Label for GPT model selector"
+  },
+  "replySummaryPrompt": {
+    "message": "Resumé de la réponse:",
+    "description": "Instructions pour le résumé de la réponse"
+  }
 }

--- a/src/inject.js
+++ b/src/inject.js
@@ -85,7 +85,17 @@ async function buttonClick(button) {
 	button.classList.replace('normal', 'loading');
 	button.prepend(loader)
 
-	let prompt = chrome.i18n.getMessage('instructions') + htmlToPlainText(document.querySelector(SELECTOR_PREV_EMAIL_CONTENT).innerHTML) + '\n"""';
+  let emailContent = htmlToPlainText(document.querySelector(SELECTOR_PREV_EMAIL_CONTENT).innerHTML);
+
+  // Ask for a summary from the user
+  let replySummary = window.prompt(chrome.i18n.getMessage('replySummaryPrompt'));
+
+  let prompt;
+  if (replySummary) { // User provided a summary for the reply.
+    prompt = chrome.i18n.getMessage('instructionsWithSummary', [emailContent, replySummary])
+  } else { // User did NOT provide a summary for the reply.
+    prompt = chrome.i18n.getMessage('instructions', [emailContent])
+  }
 
 	let result;
 	try {


### PR DESCRIPTION
With this PR, a popup opens after clicking the generate button.
In the popup, the user can write a summary of what they want to include in the reply, like "I agree" or "please send more details". 
If the popup is closed without text, the old prompt is used. If text is provided, a different prompt is used that includes the summary as well as the original email text.

The popup doesn't look very nice. It uses the standard window.prompt() JavaScript method, but it works for me.

I also replaced the concatenation in line 88 of inject.js with placeholders in the messages.

Note 1: Although I also speak French, I did not try the French prompt. Only the English one.
Note 2: The French messages.json was formatted differently than the English one. I took the liberty to reformat it too.